### PR TITLE
feat/pinコード登録機能追加

### DIFF
--- a/src/apps/user/forms.py
+++ b/src/apps/user/forms.py
@@ -39,22 +39,33 @@ class JoinCodeForm(forms.Form):
             raise forms.ValidationError('参加コードは8桁の数字で入力してください。')
         return v
 
-class PinForm(forms.Form):
+class PinSetForm(forms.Form):
+    pin1 = forms.CharField(
+        label="PINコード（4桁）",
+        min_length=4, max_length=4,
+        widget=forms.PasswordInput(attrs={"inputmode": "numeric", "autocomplete": "off"})
+    )
+    pin2 = forms.CharField(
+        label="PIN（確認）",
+        min_length=4, max_length=4,
+        widget=forms.PasswordInput(attrs={"inputmode": "numeric", "autocomplete": "off"})
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        p1 = cleaned.get('pin1', '')
+        p2 = cleaned.get('pin2', '')
+        if not (p1.isdigit() and p2.isdigit()):
+            raise forms.ValidationError('PINは数字4桁で入力してください。')
+        if p1 != p2:
+            raise forms.ValidationError('確認用PINが一致しません。')
+        return cleaned
+
+class PinVerifyForm(forms.Form):
     pin = forms.CharField(
-        label='４桁のPINコード',
-        min_length=4,
-        max_length=4,
-        widget=forms.PasswordInput(attrs={
-            'inputmode': 'numeric',
-            'pattern': r'\d{4}',
-            'maxlength': '4',
-            'placeholder': '••••',
-        }),
-        error_messages={
-            'required': 'PINコードを入力してください',
-            'min_length': 'PINコードは４桁です',
-            'max_length': 'PINコードは４桁です',
-        },   
+        label='PIN（4桁）',
+        min_length=4, max_length=4,
+        widget=forms.PasswordInput(attrs={'inputmode': 'numeric', 'autocomplete': 'off'})
     )
 
     def clean_pin(self):

--- a/src/templates/user/login.html
+++ b/src/templates/user/login.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}PIN 入力{% endblock %}
+{% block title %}PIN 登録{% endblock %}
 
 {% block css %}
   <link rel="stylesheet" href="{% static 'css/components/button.css' %}">
@@ -15,16 +15,13 @@
 {% include "components/top_nav.html" %}
 {% endblock %}
 
-{% block page_title %} PINコードの入力 {% endblock %}
+{% block page_title %} PINコードを登録 {% endblock %}
 {% block content %}
   <p class="pin_target">対象プロフィール：<strong>{{ member.display_name }}</strong></p>
-  <div class="caution_text">
-    <p>PINコードを入力してください。</p>
-    <p>５回間違えるとロックがかかります。</p>
-  </div>
+
   <form method="post">{% csrf_token %}
     {{ form.as_p }}
-    <button class="btn-primary" type="submit">入室する</button>
+    <button class="btn-primary" type="submit">登録する</button>
   </form>
   <p class="link_set">
     <a href="/profiles/" class="btn btn-secondary">プロフィールへ戻る</a>

--- a/src/templates/user/profile_enter.html
+++ b/src/templates/user/profile_enter.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static %}
 
-{% block title %}PIN 登録{% endblock %}
+{% block title %}PINコードを入力{% endblock %}
 
 {% block css %}
   <link rel="stylesheet" href="{% static 'css/components/button.css' %}">
@@ -15,13 +15,15 @@
 {% include "components/top_nav.html" %}
 {% endblock %}
 
-{% block page_title %} PINコードの登録 {% endblock %}
+{% block page_title %} PINコードを入力 {% endblock %}
 {% block content %}
   <p class="pin_target">対象プロフィール：<strong>{{ member.display_name }}</strong></p>
-
+  <div class="caution_text">
+    <p>５回間違えるとロックがかかります。</p>
+  </div>
   <form method="post">{% csrf_token %}
     {{ form.as_p }}
-    <button class="btn btn-primary" type="submit">登録して入室する</button>
+    <button class="btn btn-primary" type="submit">入室する</button>
   </form>
   <p class="link_set">
     <a href="/profiles/" class="btn btn-secondary">プロフィールへ戻る</a>
@@ -32,4 +34,3 @@
 {% block footer %}
 {% include "components/bottom_nav_before_login.html" %}
 {% endblock %}
-


### PR DESCRIPTION
### 目的
・ダッシュボードにログインする際の初回と二回目以降でHTMLを分ける。
⇒それに伴い`login.html`,　`owner_login.html`の<p>タグ内の文言を修正。
・pinコードを登録する際に一回で登録するのではなく、確認も行う。

### ローカル検証
**新規登録を既にしている方**
[http:localhost:8000/dashboard/](http:localhost:8000/dashboard/)にアクセスし、新しいプロフィールを追加ー＞ダッシュボードにログインしようとすると、新しいユーザーではPINコードを登録と既存ユーザーはPINコード入力と表示される。

**新規登録をしていない方**
管理者の新規登録を済ませて上記の手順を行ってください。
