### PR TITLE
代役、多忙フラグ

### DIFF
--- a/src/apps/dashboard/urls.py
+++ b/src/apps/dashboard/urls.py
@@ -1,9 +1,13 @@
 from django.urls import path
 from .view import DashboardView, ToggleTaskDoneView
+from .view import request_substitute, accept_substitute, toggle_busy
 
 app_name = "dashboard"
 
 urlpatterns = [
     path('', DashboardView.as_view(), name="dashboard"),
     path("tasks/<int:pk>/toggle/", ToggleTaskDoneView.as_view(), name="task_toggle"),
+    path("tasks/<int:task_id>/request_substitute/", request_substitute, name="request_substitute"),
+    path("tasks/<int:task_id>/accept_substitute/", accept_substitute, name="accept_substitute"),
+    path("toggle-busy/", toggle_busy, name="toggle_busy"),
 ]


### PR DESCRIPTION
多忙フラグ
自分の今日の担当の家事がある状態で多忙フラグをタップし、再割り当てするとすべての家事が無くなる=スキップ
代役
代役依頼をタップ→他のユーザで代役を引き受ける→今日の自分の担当に追加
